### PR TITLE
update the symlink for globals

### DIFF
--- a/_scss/globals
+++ b/_scss/globals
@@ -1,1 +1,1 @@
-/Users/georgespeach/Documents/core-support/armydotmil.github.io/_scss
+../armydotmil.github.io/_scss


### PR DESCRIPTION
The symlink was using an absolute path and it needs to be relative within the project directory.